### PR TITLE
plat-498 fixing config path for notification service extra attributes

### DIFF
--- a/pkg/output/httptransformer/notification_serivce_transformer.go
+++ b/pkg/output/httptransformer/notification_serivce_transformer.go
@@ -39,7 +39,8 @@ func init() {
 
 // NewNotificationServiceTransformer creates new transformer
 func NewNotificationServiceTransformer(config *viper.Viper) ResponseBodyTransformer {
-	extraAttr := config.GetStringMapString("output.notification_service_transformer.extra_attributes")
+	extraAttr := config.GetStringMapString("output.http.notification_service_transformer.extra_attributes")
+
 	return &NotificationServiceTransformer{
 		hostname:        getHostname(),
 		noTopicToStdOut: false,


### PR DESCRIPTION
Problem: the pauditd extra attributes configuration for notification service was not picking up the configuration options due to the wrong config path in viper being specified

Solution: set the right path