### PR TITLE
PLAT-1210 Fix two race conditions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build-linux:
 	GOOS=linux GOARCH=amd64 go build
 
 test:
-	go test $$(go list ./...)
+	go test $$(go list ./...) -race
 
 test-cov-html:
 	go test -coverprofile=coverage.out

--- a/client_test.go
+++ b/client_test.go
@@ -94,6 +94,7 @@ func TestNewNetlinkClient(t *testing.T) {
 	defer resetLogger()
 
 	n, err := NewNetlinkClient(1024)
+	n.Close()
 
 	assert.Nil(t, err)
 	if n == nil {

--- a/pkg/output/file_writer.go
+++ b/pkg/output/file_writer.go
@@ -86,7 +86,6 @@ func handleLogRotation(config *viper.Viper, writer *AuditWriter) {
 
 		oldFile := writer.w.(*os.File)
 		writer.w = newWriter.w
-		writer.e = newWriter.e
 
 		err = oldFile.Close()
 		if err != nil {

--- a/pkg/output/writer_race_test.go
+++ b/pkg/output/writer_race_test.go
@@ -1,0 +1,73 @@
+// +build race
+
+package output
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/pantheon-systems/pauditd/pkg/parser"
+)
+
+// Tests against a race condition.
+// To marshal and write JSON to its wrapped writer, `AuditWriter` was using the
+// `(json.Encoder).Encode(msg)` function available in the `json` library.
+// When the wrapped writer makes its own calls to the `json` marshalling functions,
+// the `json` library's internal state is accessed concurrently.
+// The bug was fixed by altering `AuditWriter` to marshal and write in two steps.
+// https://getpantheon.atlassian.net/browse/PLAT-1210
+func TestAuditWriterRace(t *testing.T) {
+	messageCount := 10
+
+	// Wrapped writer
+	writer := &raceWriter{
+		messages: make(chan []byte),
+		cancel:   make(chan struct{}),
+	}
+
+	// Test subject
+	subject := NewAuditWriter(writer, 1)
+
+	// Deploy a worker
+	go writer.runWorker()
+
+	// Write a bunch of messages
+	for i := 0; i < messageCount; i++ {
+		amg := &parser.AuditMessageGroup{}
+		if err := subject.Write(amg); err != nil {
+			t.Error(err)
+		}
+	}
+
+	// Stop worker
+	close(writer.cancel)
+}
+
+type raceWriter struct {
+	messages chan []byte
+	cancel   chan struct{}
+}
+
+// Implement `io.Writer`
+func (w raceWriter) Write(p []byte) (n int, err error) {
+	w.messages <- p
+
+	return 0, nil
+}
+
+func (w *raceWriter) runWorker() {
+	for {
+		select {
+		case <-w.cancel:
+			return
+		case message := <-w.messages:
+
+			// Call json.Marshal like HTTPWriter
+			_, err := json.Marshal(message)
+
+			if err != nil {
+				panic(err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
The fix to `writer.go` is the more important fix here because it should stop the invalid JSON being sent to notification service.

The other race condition fix in `client.go` was just happening in a unit test, so fixing it allowed me to add `-race` to `make test`, like it is in common_makefiles.