### PR TITLE
pin goreleaser back to v0.119.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,8 @@ jobs:
             xargs curl -o ~/autotag -L \
             && chmod 755 ~/autotag
       - run: ~/autotag
-      - run: curl -sL https://git.io/goreleaser | bash -s -- --parallelism=2
+      #- run: curl -sL https://git.io/goreleaser | bash -s -- --parallelism=2
+      - run: curl -sL https://git.io/goreleaser | VERSION=v0.119.0 bash -s -- --parallelism=2
       - store_artifacts:
           path: /home/circleci/pauditd/dist
       - persist_to_workspace:


### PR DESCRIPTION
still seeing some issues pushing rpm's to packagecloud, returning '500 internal server errors' now. try pin back to 0.119 to see if its another issue with the new nfpm code