### PR TITLE
remove goreleaser version pin, bug with packagecloud is fixed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,7 @@ jobs:
             xargs curl -o ~/autotag -L \
             && chmod 755 ~/autotag
       - run: ~/autotag
-      #- run: curl -sL https://git.io/goreleaser | bash -s -- --parallelism=2
-      - run: curl -sL https://git.io/goreleaser | VERSION=v0.119.0 bash -s -- --parallelism=2
+      - run: curl -sL https://git.io/goreleaser | bash -s -- --parallelism=2
       - store_artifacts:
           path: /home/circleci/pauditd/dist
       - persist_to_workspace:

--- a/go.mod
+++ b/go.mod
@@ -14,3 +14,5 @@ require (
 	golang.org/x/sys v0.0.0-20181011152604-fa43e7bc11ba // indirect
 	gopkg.in/alexcesaro/statsd.v2 v2.0.0
 )
+
+go 1.13


### PR DESCRIPTION
fixed in v0.120.8: https://github.com/goreleaser/goreleaser/issues/1229