### PR TITLE
Bump the circle build image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/golang:1.12
+      - image: cimg/go:1.18
     working_directory: /home/circleci/pauditd
     steps:
       - checkout
@@ -15,7 +15,7 @@ jobs:
 
   build-release:
     docker:
-      - image: circleci/golang:1.12
+      - image: cimg/go:1.18
     working_directory: /home/circleci/pauditd
     steps:
       - attach_workspace:


### PR DESCRIPTION
The circle build image we're using is deprecated: https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034

And while I'm here, bump the Go version of the build image as well.