### PR TITLE
PLAT-2878 Use circleci context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,8 +57,13 @@ workflows:
   version: 2
   test-build-release:
     jobs:
-      - test
+      - test:
+          context:
+            - docker-executor-auth
       - build-release:
+          context:
+            - docker-executor-auth
+            - sig-go-release
           requires:
             - test
           filters:


### PR DESCRIPTION
Rotating CircleCI environment variables. Moving env vars to context so rotating can be done at the context-level. The secret environment variables have been deleted from this project in CircleCI and instead the context is being used.

https://app.circleci.com/settings/project/github/pantheon-systems/pauditd/environment-variables

## Issue ID
https://getpantheon.atlassian.net/browse/PLAT-2878