### PR TITLE
Jeli 75

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,6 @@ jobs:
       - run: package_cloud push pantheon/public/fedora/29 ./dist/*.rpm
       - run: package_cloud push pantheon/public/el/7 ./dist/*.rpm
 
-
 workflows:
   version: 2
   test-build-release:
@@ -66,10 +65,6 @@ workflows:
             - sig-go-release
           requires:
             - test
-          filters:
-            branches:
-              only:
-                - master
       - publish-rpm:
           requires:
             - build-release
@@ -77,4 +72,3 @@ workflows:
             branches:
               only:
                 - master
-

--- a/audit.go
+++ b/audit.go
@@ -244,6 +244,12 @@ func fetchRmemMax() int {
 }
 
 func handleMsg(msg *syscall.NetlinkMessage, marshaller *marshaller.AuditMarshaller) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error.Printf("Panic occurred in handleMsg: %v", r)
+		}
+	}()
+
 	timing := metric.GetClient().NewTiming() // measure latency from recipt of message
 	metric.GetClient().Increment("messages.total")
 

--- a/client_test.go
+++ b/client_test.go
@@ -103,8 +103,6 @@ func TestNewNetlinkClient(t *testing.T) {
 		assert.True(t, (n.fd > 0), "No file descriptor")
 		assert.True(t, (n.address != nil), "Address was nil")
 		assert.Equal(t, uint32(0), n.seq, "Seq should start at 0")
-		assert.True(t, MAX_AUDIT_MESSAGE_LENGTH >= len(n.buf), "Client buffer is too small")
-
 		assert.Equal(t, "Socket receive buffer size: ", lb.String()[:28], "Expected some nice log lines")
 		assert.Equal(t, "", elb.String(), "Did not expect any error messages")
 	}


### PR DESCRIPTION
- try and handle messages async, letting the main loop receive as fast as possible
  - could spawn an ever increasing amount of subroutines, we'll see if it can't keep up or not
  - use a new buffer for each receive call to fetch/read messages from
- handle large messages
- dynamically fetch the max buffer size from rmem_max (mounted in)
  - will fallback to config value if not found 