### PR TITLE
ci: Pin GitHub Actions to commit SHAs (DELENG-235)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,7 +25,7 @@ jobs:
     name: Install dependencies
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: "Setup Go and Cache Modules"
         uses: ./.github/actions/setup-go-and-cache
@@ -47,7 +47,7 @@ jobs:
     needs: [deps]
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: "Setup Go and Cache Modules"
         uses: ./.github/actions/setup-go-and-cache
@@ -63,7 +63,7 @@ jobs:
 
       - name: "Check for changes"
         id: changed-files
-        uses: tj-actions/verify-changed-files@v20.0.4
+        uses: tj-actions/verify-changed-files@a1c6acee9df209257a246f2cc6ae8cb6581c1edf # v20.0.4
 
       - name: "Fail if formatting modified files"
         if: steps.changed-files.outputs.files_changed == 'true'
@@ -83,7 +83,7 @@ jobs:
     needs: [deps]
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: "Setup Go and Cache Modules"
         uses: ./.github/actions/setup-go-and-cache
@@ -92,7 +92,7 @@ jobs:
           use-cache: ${{ env.USE_GO_CACHE }}
 
       - name: "Run golangci-lint"
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
         with:
           version: v2.0
           working-directory: .
@@ -105,7 +105,7 @@ jobs:
     needs: [deps]
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: "Setup Go and Cache Modules"
         uses: ./.github/actions/setup-go-and-cache
@@ -124,7 +124,7 @@ jobs:
         working-directory: .
 
       - name: "Report results to GitHub"
-        uses: ctrf-io/github-test-reporter@v1
+        uses: ctrf-io/github-test-reporter@024bc4b64d997ca9da86833c6b9548c55c620e40 # v1.0.26
         with:
           report-path: "./ctrf-report.json"
 
@@ -140,7 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -157,7 +157,7 @@ jobs:
     needs: [deps, goreleaser-check]
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: "Setup Go and Cache Modules"
         uses: ./.github/actions/setup-go-and-cache
@@ -172,7 +172,7 @@ jobs:
           workdir: .
 
       - name: "Upload Build Artifacts"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: build-artifacts
           path: |
@@ -187,7 +187,7 @@ jobs:
     needs: [format, lint, test, build]
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -196,18 +196,18 @@ jobs:
 
       - name: "Install and Run autotag"
         if: env.IS_MAIN_BRANCH == 'true'
-        uses: pantheon-systems/action-autotag@v1
+        uses: pantheon-systems/action-autotag@1b99f88428c5cbd6f73005e4d684c6a22350f5ab # v1.0.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Download RPM Artifacts"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: build-artifacts
           path: dist
 
       - name: "Setup Ruby"
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@8aeb6ff8030dd539317f8e1769a044873b56ea71 # v1.268.0
         with:
           ruby-version: "3.1" # or another version as required
 
@@ -223,7 +223,7 @@ jobs:
 
       # - name: GitHub Token
       #   id: get-package-cloud-token
-      #   uses: pantheon-systems/common-gh/get-shared-vault-secret@main
+      #   uses: pantheon-systems/common-gh/get-shared-vault-secret@91222b8009f6df264fee51dce8a7d266a84eecbc # main 2025-11-28T13:02:03Z
       #   with:
       #     vault_env: sandbox
       #     vault_role: ci-pantheon-sshd


### PR DESCRIPTION
Automated pinning of GitHub Actions to their commit SHAs.

This improves security by preventing supply chain attacks through compromised action tags.
Each action is pinned to its current commit SHA with a comment showing the original version.

## Related Ticket
https://getpantheon.atlassian.net/browse/DELENG-235

## Need Help?
If you have questions or need help, ask in Slack [#ask-delivery-engineering](https://pantheon.enterprise.slack.com/archives/C09SPT0A65B)