### PR TITLE
chore: Update FROM alpine:3.21 → 3.22 (DELENG-236)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21
+FROM us-docker.pkg.dev/pantheon-artifacts/internal/alpine:3.22
 
 RUN apk add audit
 


### PR DESCRIPTION
Automated update of FROM alpine:3.21 to FROM us-docker.pkg.dev/pantheon-artifacts/internal/alpine:3.22

## Related Ticket
https://getpantheon.atlassian.net/browse/DELENG-236

## Need Help?
If you have questions or need help, ask in Slack [#ask-delivery-engineering](https://pantheon.enterprise.slack.com/archives/C09SPT0A65B)