### PR TITLE
ci: Add github-actions ecosystem to dependabot.yml (DELENG-239)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,10 @@ updates:
     directory: /
     schedule:
       interval: daily
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Dependabot doesn't support private repositories with actions/workflows
+    ignore:
+      - dependency-name: "pantheon-systems/*"


### PR DESCRIPTION
Automated update to add github-actions package ecosystem to dependabot.yml.

This ensures Dependabot will automatically update GitHub Actions versions used in workflows.

## Related Ticket
https://getpantheon.atlassian.net/browse/DELENG-239

## Need Help?
If you have questions or need help, ask in Slack [#ask-delivery-engineering](https://pantheon.enterprise.slack.com/archives/C09SPT0A65B)