### PR TITLE
DELENG-434: Remove deprecated platform team from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # https://help.github.com/en/articles/about-code-owners
 
-* @pantheon-systems/platform @pantheon-systems/pie
+* @pantheon-systems/pie


### PR DESCRIPTION
## Summary
Removes `@pantheon-systems/platform` from CODEOWNERS as this GitHub team is being deprecated.

## Changes
- Updated CODEOWNERS: removed `@pantheon-systems/platform`
- Team providing coverage: `@pantheon-systems/pie`

## Context
The `platform` team is being deprecated as part of repository ownership cleanup (DELENG-428).

**Note:** This repo is marked as deprecated (lifecycle: deprecated).

## Jira
- [DELENG-434](https://getpantheon.atlassian.net/browse/DELENG-434)

[DELENG-434]: https://getpantheon.atlassian.net/browse/DELENG-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ